### PR TITLE
Tweak to Relation.php for increased compatibility and stability

### DIFF
--- a/user/components/Relation.php
+++ b/user/components/Relation.php
@@ -720,8 +720,8 @@ echo '</ul>';
 					array('multiple' => 'multiple'));
 		}
 
-		public function handleAjaxRequest($_POST) {
-			print_r($_POST);
+		public function handleAjaxRequest($POST) {
+			print_r($POST);
 		}
 
 		public function renderTwoPaneSelection() 


### PR DESCRIPTION
Relation.php references the $_POST global variable as though it were a parameter. This caused my MAMP installation to crash when rendering any page referencing this particular file. The fix was to rename the $_POST parameter to simply $POST, so as to not be conflicting with the auto-global $_POST.
