### PR TITLE
Make recovery email validation pattern match CEmailValidator

### DIFF
--- a/registration/RegistrationModule.php
+++ b/registration/RegistrationModule.php
@@ -17,7 +17,7 @@ class RegistrationModule extends CWebModule {
 	// Whether to confirm the activation of an user by email
 	public $enableActivationConfirmation = true; 
 
-	public $validEmailPattern = '/^[A-Za-z0-9@.\s,]+$/u';
+	public $validEmailPattern = '/^[a-zA-Z0-9!#$%&\'*+\\/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&\'*+\\/=?^_`{|}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/';
 
 	public $registrationEmail='register@website.com';
 	public $recoveryEmail='restore@website.com';


### PR DESCRIPTION
certain email address will succeed on registration but fail on recovery if the patterns do not match.
