### PR TITLE
Enforce avatarThumbnailWidth parameter in YumUser->getAvatar()

### DIFF
--- a/user/models/YumUser.php
+++ b/user/models/YumUser.php
@@ -740,7 +740,7 @@ class YumUser extends YumActiveRecord
 		if (Yum::hasModule('avatar') && $this->profile) {
 			$options = array();
 			if ($thumb)
-				$options = array('class' => 'avatar', 'style' => 'width: 40px; height:40px;');
+				$options = array('class' => 'avatar', 'style' => 'width: ' . Yum::module('avatar')->avatarThumbnailWidth . ' px;');
 			else
 				$options = array('class' => 'avatar', 'style' => 'width: ' . Yum::module('avatar')->avatarDisplayWidth . ' px;');
 


### PR DESCRIPTION
Currently getAvatar assigns a fixed width of 40px to thumbnails - this fix will force YumUser to utilize avatarThumbnailWidth parameter
