### PR TITLE
Update profile/controllers/YumProfileController.php

### DIFF
--- a/profile/controllers/YumProfileController.php
+++ b/profile/controllers/YumProfileController.php
@@ -76,9 +76,19 @@ class YumProfileController extends YumController {
 		return parent::beforeAction($action);
 	}
 
-	public function loadModel($id = null) {
-		if(!$id)
+	public function loadModel($id = null) { 
+		if(!$id){
 			$id = Yii::app()->user->id;
+		}
+		else{
+			$sql='
+				SELECT user_id
+				FROM tbl_profile
+				WHERE id = '. $id .'
+			';	
+			$result = Yii::app()->db->createCommand($sql)->queryRow();
+			$id 	= $result['user_id'];
+		}
 
 		if(is_numeric($id))
 			return $this->_model = YumUser::model()->findByPk($id);


### PR DESCRIPTION
I think there is a bug here.
Scenario:
-user registers but doesn't make a profile yet.
-another user registers and makes a profile
- profile_id is not equal user_id
  in this case when we are executing loadModel($id) we are using profile_id and querying tbl_user primary key.

I'm not sure if this is the best solution but I'm querying tbl_profile first to get a user_id and then use it to get YumUser model.
