### PR TITLE
Fix improper performAjaxValidation call in YumMessageController.php

### DIFF
--- a/message/controllers/YumMessageController.php
+++ b/message/controllers/YumMessageController.php
@@ -64,11 +64,15 @@ class YumMessageController extends YumController {
 
 	public function actionCompose($to_user_id = null, $answer_to = 0) {
 		$model = new YumMessage;
-		$this->performAjaxValidation('YumMessage', 'yum-message-form');
+		$model->from_user_id = Yii::app()->user->id; /* NOTE: This line is moved here, because
+		    * otherwise 'from_user' relation will remain empty in YumMessage->beforeValidate()
+		    * method (line 34) and thus - "Trying to get property of non-object" error will be
+		    * raised.
+		    */
+		$this->performAjaxValidation($model, 'yum-message-form');
 
 		if(isset($_POST['YumMessage'])) {
 			$model->attributes = $_POST['YumMessage'];
-			$model->from_user_id = Yii::app()->user->id;
 			$model->validate();
 			if(!$model->hasErrors()) {
 				$model->save();


### PR DESCRIPTION
Attempt to fix the following issue: When user is composing YumMessage to a 'friend', although the message is send with success, the following error occurs in the logs:
Fix "[error] [php] Attempt to assign property of non-object (...) ... Stack trace: #0 unknown(0): YumMessageController->actionCompose()... YumMessageController.php (67)... 

Resolution: It seems 'performAjaxValidation' was not called with actual model object and also the object itself was with missing 'from_user' relation.