### PR TITLE
Critical Security - Privilege Scalation

### DIFF
--- a/user/controllers/YumUserController.php
+++ b/user/controllers/YumUserController.php
@@ -233,6 +233,7 @@ class YumUserController extends YumController {
 
 		if(isset($_POST['YumUser'])) {
 			$user->attributes = $_POST['YumUser'];
+			$user->scenario = Yii::app()->user->hasRole('UserManager') ? 'managerUserUpdate' : 'userUpdate';
 
 			$user->validate();
 			if($profile && isset($_POST['YumProfile']) )


### PR DESCRIPTION
Any user can tamper the update (insert, registration and so on) request, for privilege scalation, setting the YumUser[superuser] parameter to 1.
